### PR TITLE
chapter7_code.R and Rmd Edits:

### DIFF
--- a/HCH7-JLEM-Math447.Rmd
+++ b/HCH7-JLEM-Math447.Rmd
@@ -49,14 +49,15 @@ Rep <- rep(c("I","II","III","IV"), each = 4)
 Vibes <- c(18.2, 27.2, 15.9, 41.0, 18.9, 24.0, 14.5, 43.9, 12.9, 22.4, 15.1, 36.3, 14.4, 22.5, 14.2, 39.9)
 router.long <- data.frame(A, B, Rep, Vibes)
 
-for (j in 1:2)
-  router.long[, j]=as.numeric(coded(router.long[, j]))
-
 # defining coded
 coded=function(x) #a function to code variable x
 {
   ifelse(x=="+", 1, -1)
 }
+
+# coding A and B
+for (j in 1:2)
+  router.long[, j]=as.numeric(coded(router.long[, j]))
 
 #######
 router.long$Block=router.long$A * router.long$B
@@ -90,19 +91,12 @@ C = Cell.Size = c(1,-1,-1,-1,1,1,-1,1,1,1,1,1,-1,-1,-1,-1)
 D = Writing.Speed = c(-1,1,1,1,-1,1,-1,-1,1,1,-1,1,-1,-1,-1,1)
 UEC = c(0.8,0.81,0.79,0.6,0.65,0.55,0.98,0.67,0.69,0.56,0.63,0.65,0.75,0.72,0.98,0.63)
 error = data.frame(Standard.Order,Run.Order,A,B,C,D,UEC)
-# defining coded
-coded=function(x) #a function to code variable x
-{
-  ifelse(x=="+", 1, -1)
-}
 
-for (j in 1:4)
-  error[, j]=as.numeric(coded(error[, j]))
 #Blocking#
-error$Block=error$A * error$B *error$C * error$D
+error$Block=error$A * error$B * error$C * error$D
 #Linear Model#
-error.lm = lm(UEC ~ Block + coded(A)*coded(B)*coded(C)*coded(D), error)#blocking
-error.lm.og = lm(UEC ~ coded(A)*coded(B)*coded(C)*coded(D), error)#regular
+error.lm = lm(UEC ~ Block + A*B*C*D, error)#blocking
+error.lm.og = lm(UEC ~ A*B*C*D, error)#regular
 
 summary(error.lm); summary(error.lm.og)
 ```

--- a/chapter7_code.R
+++ b/chapter7_code.R
@@ -1,0 +1,60 @@
+#############################################
+##     Blocking a replicated design         #
+#############################################
+#Yield data (pp. 234)
+yield=read.table("data/yield.txt", header = TRUE)
+summary(aov(Yield ~ Rep + A * B, yield)) #analysis of design with blocking
+summary(aov(Yield ~ A * B, yield)) # analysis of design without blocking
+
+#recode the data: x=1 at level +; X=-1 at level -
+coded=function(x) #a function to code variable x
+{
+  ifelse(x=="+", 1, -1)
+}
+###############################################
+##     confounding a 2^K desgin in 2 blocks ### 
+###############################################
+#filtration rate data (eg. 6.2/7.2 page 257/310)
+filtration=read.table("data/filtration.txt", header = TRUE)
+for (j in 1:4)
+  filtration[, j]=as.numeric(coded(filtration[, j]))
+#factors have already been converted from "-","+" to -1, +1 coding
+#Note that ABCD cannot be estimated, because it is confounded with blocks
+filtration$Block=filtration$A * filtration$B *filtration$C * filtration$D
+summary(lm(Rate ~ Block + A * B * C * D, filtration))
+#Note that the estimates identical to the ones obstained when there was no block effect
+summary(lm(Rate ~ A * B * C * D, filtration)) 
+
+#reduced model
+#Note that all effects in the reduced model can be estimated and tested.
+summary(aov(Rate ~ Block + A + C + D + A * C + A * D, filtration))
+
+
+#############################################
+##     partical confounding                 #
+#############################################
+#2^3 design, 2 replicates, each in 2 blocks, with ABC confounded with blocks in Rep I, 
+#and AB confounded in Rep II (plasma etching tool data)
+plasma=read.table("data/plasma.txt", header = TRUE)
+plasmaLong=reshape(plasma, varying = c("Rep1", "Rep2"), v.names = "Rate",
+                   direction = "long", timevar = "Rep")
+plasmaLongRep1=plasmaLong[plasmaLong$Rep == 1,]
+A=coded(plasmaLongRep1$A)
+B=coded(plasmaLongRep1$B)
+C=coded(plasmaLongRep1$C)
+plasmaLongRep1$Block=ifelse(A * B * C < 0, 1, 2)
+plasmaLongRep1=plasmaLongRep1[order(plasmaLongRep1$Block),]
+plasmaLongRep2=plasmaLong[plasmaLong$Rep == 2,]
+A=coded(plasmaLongRep2$A)
+B=coded(plasmaLongRep2$B)
+plasmaLongRep2$Block=ifelse(A * B > 0, 1, 2)
+plasmaLongRep2=plasmaLongRep2[order(plasmaLongRep2$Block),]
+partialConfounding=rbind(plasmaLongRep1, plasmaLongRep2)
+partialConfounding$Rep=factor(partialConfounding$Rep)
+partialConfounding$Blocks=factor(paste(partialConfounding$Rep,
+                                       partialConfounding$Block,sep = "-"))
+summary(aov(Rate ~ Blocks + A * B * C, partialConfounding))
+#Note larger standard errors for partially confounded effects (*sqrt(2)):
+summary(lm(Rate ~ Blocks + coded(A) * coded(B) * coded(C),
+             partialConfounding))
+


### PR DESCRIPTION
chapter7_code.R:
- code added for easy access

7.2:
- moved coded lines up (code doesn't work if 7.1 code block wasn't run)

7.13:
- deleted redundant code (factor values are already numeric)

I suspect the reason behind our NAs are 0 degrees of freedom from one set of replicates.  Oddly enough, her example code runs into the same issues.  I'm merging it into our documents.